### PR TITLE
Add scoring and new obstacle types

### DIFF
--- a/car_game.py
+++ b/car_game.py
@@ -16,6 +16,8 @@ WHITE = (255, 255, 255)
 BLACK = (0, 0, 0)
 RED = (200, 0, 0)
 BLUE = (0, 0, 255)
+GREEN = (0, 180, 0)
+YELLOW = (200, 200, 0)
 
 # Road and scenery colors
 ROAD_COLOR = (40, 40, 40)
@@ -41,6 +43,10 @@ OBSTACLE_HEIGHT = 60
 obstacle_speed = 5
 obstacles = []
 
+# Scoring
+money = 0
+equipment = 0
+
 # Pre-generate simple buildings along the sidewalks
 buildings = []
 for side in (0, WIDTH - SIDEWALK_WIDTH):
@@ -55,12 +61,20 @@ for side in (0, WIDTH - SIDEWALK_WIDTH):
 font = pygame.font.SysFont(None, 36)
 
 def create_obstacle():
-    """Create a new obstacle within the road area."""
+    """Create a new obstacle of random type within the road area."""
+    obstacle_types = [
+        {"width": 40, "height": 60, "color": RED, "money": -5, "equipment": 0},
+        {"width": 60, "height": 80, "color": GREEN, "money": 3, "equipment": 0},
+        {"width": 30, "height": 40, "color": GREEN, "money": 1, "equipment": 0},
+        {"width": 40, "height": 40, "color": YELLOW, "money": 0, "equipment": 1},
+    ]
+    info = random.choice(obstacle_types)
     x_min = SIDEWALK_WIDTH
-    x_max = WIDTH - SIDEWALK_WIDTH - OBSTACLE_WIDTH
+    x_max = WIDTH - SIDEWALK_WIDTH - info["width"]
     x = random.randint(x_min, x_max)
-    rect = pygame.Rect(x, -OBSTACLE_HEIGHT, OBSTACLE_WIDTH, OBSTACLE_HEIGHT)
-    return rect
+    rect = pygame.Rect(x, -info["height"], info["width"], info["height"])
+    info["rect"] = rect
+    return info
 
 # Game loop
 running = True
@@ -88,7 +102,57 @@ while running:
 
     # Move obstacles
     for obs in obstacles:
-        obs.y += obstacle_speed
+        obs["rect"].y += obstacle_speed
 
     # Remove off-screen obstacles
-    obstacles = [obs for obs in obstacles]()
+    obstacles = [obs for obs in obstacles if obs["rect"].y < HEIGHT]
+
+    # Check collisions
+    car_rect = pygame.Rect(car_x, car_y, CAR_WIDTH, CAR_HEIGHT)
+    for obs in obstacles[:]:
+        if car_rect.colliderect(obs["rect"]):
+            money += obs["money"]
+            equipment += obs["equipment"]
+            obstacles.remove(obs)
+
+    # Drawing
+    screen.fill(BLACK)
+
+    # Draw sidewalks
+    pygame.draw.rect(screen, SIDEWALK_COLOR, (0, 0, SIDEWALK_WIDTH, HEIGHT))
+    pygame.draw.rect(screen, SIDEWALK_COLOR, (WIDTH - SIDEWALK_WIDTH, 0, SIDEWALK_WIDTH, HEIGHT))
+
+    # Draw buildings
+    for rect in buildings:
+        pygame.draw.rect(screen, BUILDING_COLOR, rect)
+
+    # Draw road
+    pygame.draw.rect(screen, ROAD_COLOR, (SIDEWALK_WIDTH, 0, ROAD_WIDTH, HEIGHT))
+
+    # Draw lane lines
+    for i in range(1, LANE_COUNT):
+        x = SIDEWALK_WIDTH + i * LANE_WIDTH
+        pygame.draw.line(screen, WHITE, (x, 0), (x, HEIGHT), 2)
+
+    # Draw car
+    pygame.draw.rect(screen, BLUE, car_rect)
+
+    # Draw obstacles
+    for obs in obstacles:
+        pygame.draw.rect(screen, obs["color"], obs["rect"])
+
+    # Draw timer
+    elapsed_sec = (pygame.time.get_ticks() - start_ticks) / 1000
+    timer_surface = font.render(f"{elapsed_sec:.1f}", True, WHITE)
+    screen.blit(timer_surface, (10, 10))
+
+    # Draw scores
+    money_surface = font.render(f"Money: {money}", True, WHITE)
+    equipment_surface = font.render(f"Equip: {equipment}", True, WHITE)
+    screen.blit(money_surface, (WIDTH - money_surface.get_width() - 10, 10))
+    screen.blit(equipment_surface, (WIDTH - equipment_surface.get_width() - 10,
+                                    40))
+
+    pygame.display.flip()
+
+pygame.quit()


### PR DESCRIPTION
## Summary
- introduce money and equipment scores shown in top right
- spawn new obstacle types for money and equipment
- update collision logic so obstacles modify scores

## Testing
- `SDL_VIDEODRIVER=dummy python car_game.py`

------
https://chatgpt.com/codex/tasks/task_b_685539dd9f988326960fc6ac61ccccd0