### PR TITLE
Add weighted obstacle spawning

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,10 @@ python car_game.py
 A game window will open. Use the left and right arrow keys to move your car.
 Collect the green money blocks to earn points and grab yellow equipment boxes
 for extra gear. Hitting a red obstacle subtracts money. The current scores are
-displayed in the top-right corner. The timer in the top-left corner shows how 
+displayed in the top-right corner. The timer in the top-left corner shows how
 long you have survived. The road has four lanes with sidewalks and simple
 buildings on the sides.
+
+Cars appear most often, followed by small money, large money and finally the
+yellow equipment crates.
 

--- a/car_game.py
+++ b/car_game.py
@@ -63,14 +63,21 @@ font = pygame.font.SysFont(None, 36)
 # Obstacle templates
 OBSTACLE_TEMPLATES = [
     {"width": 40, "height": 60, "color": RED, "money": -5, "equipment": 0},
-    {"width": 60, "height": 80, "color": GREEN, "money": 3, "equipment": 0},
     {"width": 30, "height": 40, "color": GREEN, "money": 1, "equipment": 0},
+    {"width": 60, "height": 80, "color": GREEN, "money": 3, "equipment": 0},
     {"width": 40, "height": 40, "color": YELLOW, "money": 0, "equipment": 1},
 ]
 
+# Relative likelihood for each obstacle type. The order corresponds to
+# OBSTACLE_TEMPLATES above. Cars are most common followed by small and large
+# money blocks and finally the yellow equipment crates.
+OBSTACLE_WEIGHTS = [5, 3, 2, 1]
+
 def create_obstacle():
     """Create a new obstacle of random type within the road area."""
-    template = random.choice(OBSTACLE_TEMPLATES)
+    # Weighted choice so that cars appear most often followed by small
+    # money, large money and equipment.
+    template = random.choices(OBSTACLE_TEMPLATES, weights=OBSTACLE_WEIGHTS, k=1)[0]
     info = template.copy()
     x_min = SIDEWALK_WIDTH
     x_max = WIDTH - SIDEWALK_WIDTH - info["width"]


### PR DESCRIPTION
## Summary
- weight obstacle spawning to favor car hazards
- mention obstacle frequency in README

## Testing
- `python -m py_compile car_game.py`

------
https://chatgpt.com/codex/tasks/task_b_68555162c6ec8326b03f6bf87affd783