### PR TITLE
Add shaped placeholders for default sprites

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CarGame
 
-This is a simple Pygame-based car game. Steer your car left and right to avoid oncoming obstacles.
+This is a simple Pygame-based car game. Steer your car to avoid oncoming obstacles using the arrow keys.
 
 ## Requirements
 
@@ -21,10 +21,23 @@ Run the main game script:
 python car_game.py
 ```
 
-A game window will open. Use the left and right arrow keys to move your car.
+A game window will open. Use the arrow keys to move your car freely around the screen.
 Collect the green money blocks to earn points and grab yellow equipment boxes
 for extra gear. Hitting a red obstacle subtracts money. The current scores are
-displayed in the top-right corner. The timer in the top-left corner shows how 
+displayed in the top-right corner. The timer in the top-left corner shows how
 long you have survived. The road has four lanes with sidewalks and simple
 buildings on the sides.
+
+Cars appear most often, followed by small money, large money and finally the
+yellow equipment crates.
+
+If you hit too many red cars and your money drops below zero, a short crash
+animation plays and the game ends. Click the **Restart** button to try again.
+
+## Customizing graphics
+
+The `assets.py` file contains placeholders for sprite images. Leave the paths
+empty and the game will draw simple car, money and crate shapes with
+transparent backgrounds. Replace the paths with PNG files to use your own
+graphics instead.
 

--- a/assets.py
+++ b/assets.py
@@ -1,0 +1,62 @@
+"""Image placeholders for CarGame assets.
+
+Edit the paths below to point to image files. When a path is left empty or the
+file does not exist, a simple colored placeholder will be drawn instead.
+Each placeholder has a transparent background and approximates the shape of the
+object so the game still looks reasonable without custom graphics.
+"""
+
+from __future__ import annotations
+
+import os
+import pygame
+from typing import Tuple
+
+# Paths to asset images. Fill these in with your own files later.
+CAR_IMAGE = ""
+CAR_OBSTACLE_IMAGE = ""
+SMALL_MONEY_IMAGE = ""
+LARGE_MONEY_IMAGE = ""
+EQUIPMENT_IMAGE = ""
+
+
+def load_sprite(
+    path: str,
+    size: Tuple[int, int],
+    color: Tuple[int, int, int],
+    shape: str = "rect",
+) -> pygame.Surface:
+    """Return a sprite surface from ``path`` or a colored placeholder.
+
+    If ``path`` points to an existing image, that image is loaded and scaled to
+    ``size``. Otherwise an alpha surface is created and ``shape`` is drawn on it
+    using ``color``.
+    """
+    if path and os.path.exists(path):
+        sprite = pygame.image.load(path).convert_alpha()
+        sprite = pygame.transform.smoothscale(sprite, size)
+        return sprite
+
+    # Draw placeholder graphic with transparent background
+    sprite = pygame.Surface(size, pygame.SRCALPHA)
+
+    if shape == "car":
+        body_rect = pygame.Rect(0, size[1] * 0.3, size[0], size[1] * 0.55)
+        pygame.draw.rect(sprite, color, body_rect, border_radius=size[0] // 8)
+        roof_rect = pygame.Rect(size[0] * 0.2, size[1] * 0.05, size[0] * 0.6, size[1] * 0.35)
+        pygame.draw.rect(sprite, color, roof_rect, border_radius=size[0] // 10)
+        wheel_radius = max(2, size[0] // 8)
+        pygame.draw.circle(sprite, (0, 0, 0), (int(size[0] * 0.25), int(size[1] * 0.9)), wheel_radius)
+        pygame.draw.circle(sprite, (0, 0, 0), (int(size[0] * 0.75), int(size[1] * 0.9)), wheel_radius)
+    elif shape == "money":
+        pygame.draw.rect(sprite, color, sprite.get_rect(), border_radius=4)
+        pygame.draw.rect(sprite, (0, 0, 0), sprite.get_rect(), 2, border_radius=4)
+    elif shape == "equipment":
+        pygame.draw.rect(sprite, color, sprite.get_rect(), border_radius=3)
+        width, height = size
+        pygame.draw.line(sprite, (0, 0, 0), (0, 0), (width, height), 2)
+        pygame.draw.line(sprite, (0, 0, 0), (width, 0), (0, height), 2)
+    else:
+        pygame.draw.rect(sprite, color, sprite.get_rect())
+
+    return sprite

--- a/car_game.py
+++ b/car_game.py
@@ -2,6 +2,15 @@ import math
 import pygame
 import random
 
+from assets import (
+    load_sprite,
+    CAR_IMAGE,
+    CAR_OBSTACLE_IMAGE,
+    SMALL_MONEY_IMAGE,
+    LARGE_MONEY_IMAGE,
+    EQUIPMENT_IMAGE,
+)
+
 # Initialize Pygame
 pygame.init()
 
@@ -60,17 +69,36 @@ for side in (0, WIDTH - SIDEWALK_WIDTH):
 # Font
 font = pygame.font.SysFont(None, 36)
 
+# Sprites - use placeholders when no images are supplied
+car_surface = load_sprite(CAR_IMAGE, (CAR_WIDTH, CAR_HEIGHT), BLUE, "car")
+OBSTACLE_SURFACES = [
+    load_sprite(CAR_OBSTACLE_IMAGE, (40, 60), RED, "car"),
+    load_sprite(SMALL_MONEY_IMAGE, (30, 40), GREEN, "money"),
+    load_sprite(LARGE_MONEY_IMAGE, (60, 80), GREEN, "money"),
+    load_sprite(EQUIPMENT_IMAGE, (40, 40), YELLOW, "equipment"),
+]
+
 # Obstacle templates
 OBSTACLE_TEMPLATES = [
-    {"width": 40, "height": 60, "color": RED, "money": -5, "equipment": 0},
-    {"width": 60, "height": 80, "color": GREEN, "money": 3, "equipment": 0},
-    {"width": 30, "height": 40, "color": GREEN, "money": 1, "equipment": 0},
-    {"width": 40, "height": 40, "color": YELLOW, "money": 0, "equipment": 1},
+    {"width": 40, "height": 60, "color": RED, "money": -5, "equipment": 0, "surface": OBSTACLE_SURFACES[0]},
+    {"width": 30, "height": 40, "color": GREEN, "money": 1, "equipment": 0, "surface": OBSTACLE_SURFACES[1]},
+    {"width": 60, "height": 80, "color": GREEN, "money": 3, "equipment": 0, "surface": OBSTACLE_SURFACES[2]},
+    {"width": 40, "height": 40, "color": YELLOW, "money": 0, "equipment": 1, "surface": OBSTACLE_SURFACES[3]},
 ]
+
+# Relative likelihood for each obstacle type. The order corresponds to
+# OBSTACLE_TEMPLATES above. Cars are most common followed by small and large
+# money blocks and finally the yellow equipment crates.
+OBSTACLE_WEIGHTS = [5, 3, 2, 1]
+
+# Duration of the crash animation in frames
+CRASH_ANIMATION_FRAMES = 30
 
 def create_obstacle():
     """Create a new obstacle of random type within the road area."""
-    template = random.choice(OBSTACLE_TEMPLATES)
+    # Weighted choice so that cars appear most often followed by small
+    # money, large money and equipment.
+    template = random.choices(OBSTACLE_TEMPLATES, weights=OBSTACLE_WEIGHTS, k=1)[0]
     info = template.copy()
     x_min = SIDEWALK_WIDTH
     x_max = WIDTH - SIDEWALK_WIDTH - info["width"]
@@ -81,55 +109,111 @@ def create_obstacle():
 
 def main() -> None:
     """Run the main game loop."""
-    global car_x, money, equipment
+    global car_x, car_y, money, equipment, obstacles
 
     running = True
     spawn_timer = 0
     start_ticks = pygame.time.get_ticks()
+
+    game_state = "playing"  # playing, crashing, game_over
+    crash_timer = 0
+    crash_obstacle_rect = None
+    restart_rect = None
+
+    def reset_game() -> None:
+        """Reset all gameplay variables to start a new run."""
+        nonlocal spawn_timer, start_ticks, game_state, crash_timer, crash_obstacle_rect, restart_rect
+        global car_x, car_y, money, equipment, obstacles
+        car_x = SIDEWALK_WIDTH + ROAD_WIDTH // 2 - CAR_WIDTH // 2
+        car_y = HEIGHT - CAR_HEIGHT - 10
+        money = 0
+        equipment = 0
+        obstacles.clear()
+        spawn_timer = 0
+        start_ticks = pygame.time.get_ticks()
+        game_state = "playing"
+        crash_timer = 0
+        crash_obstacle_rect = None
+        restart_rect = None
+
 
     while running:
         dt = clock.tick(60)
         for event in pygame.event.get():
             if event.type == pygame.QUIT:
                 running = False
+            elif game_state == "game_over" and event.type == pygame.MOUSEBUTTONDOWN:
+                if restart_rect and restart_rect.collidepoint(event.pos):
+                    reset_game()
+
+        if game_state == "game_over":
+            # Draw the game over screen and wait for restart.
+            screen.fill(BLACK)
+            over_text = font.render("You crashed, and you're broke", True, WHITE)
+            text_rect = over_text.get_rect(center=(WIDTH // 2, HEIGHT // 2 - 20))
+            screen.blit(over_text, text_rect)
+            button_surf = font.render("Restart", True, WHITE)
+            restart_rect = button_surf.get_rect(center=(WIDTH // 2, HEIGHT // 2 + 30))
+            pygame.draw.rect(screen, BLUE, restart_rect.inflate(20, 10))
+            screen.blit(button_surf, restart_rect)
+            pygame.display.flip()
+            continue
 
         keys = pygame.key.get_pressed()
-        if keys[pygame.K_LEFT] and car_x > SIDEWALK_WIDTH:
-            car_x -= car_speed
-        if keys[pygame.K_RIGHT] and car_x < WIDTH - SIDEWALK_WIDTH - CAR_WIDTH:
-            car_x += car_speed
+        if game_state == "playing":
+            if keys[pygame.K_LEFT] and car_x > SIDEWALK_WIDTH:
+                car_x -= car_speed
+            if keys[pygame.K_RIGHT] and car_x < WIDTH - SIDEWALK_WIDTH - CAR_WIDTH:
+                car_x += car_speed
+            if keys[pygame.K_UP] and car_y > 0:
+                car_y -= car_speed
+            if keys[pygame.K_DOWN] and car_y < HEIGHT - CAR_HEIGHT:
+                car_y += car_speed
 
         # Spawn obstacles
-        spawn_timer += dt
-        if spawn_timer > 1000:
-            spawn_timer = 0
-            obstacles.append(create_obstacle())
+        if game_state == "playing":
+            spawn_timer += dt
+            if spawn_timer > 1000:
+                spawn_timer = 0
+                obstacles.append(create_obstacle())
 
         # Increase speed over time
         elapsed_sec = (pygame.time.get_ticks() - start_ticks) / 1000
         obstacle_speed = BASE_OBSTACLE_SPEED + elapsed_sec * 0.1
 
         # Move obstacles
-        for obs in obstacles:
-            obs["rect"].y += obstacle_speed
+        if game_state == "playing":
+            for obs in obstacles:
+                obs["rect"].y += obstacle_speed
 
-        # Remove off-screen obstacles
-        obstacles[:] = [obs for obs in obstacles if obs["rect"].y < HEIGHT]
+            # Remove off-screen obstacles
+            obstacles[:] = [obs for obs in obstacles if obs["rect"].y < HEIGHT]
 
         # Car bounce animation
         car_offset = int(math.sin(pygame.time.get_ticks() * 0.02) * 2)
         car_rect = pygame.Rect(car_x, car_y + car_offset, CAR_WIDTH, CAR_HEIGHT)
 
         # Collision detection
-        for obs in obstacles[:]:
-            if car_rect.colliderect(obs["rect"]):
-                money += obs["money"]
-                equipment += obs["equipment"]
-                obstacles.remove(obs)
+        if game_state == "playing":
+            for obs in obstacles[:]:
+                if car_rect.colliderect(obs["rect"]):
+                    money += obs["money"]
+                    equipment += obs["equipment"]
+                    obstacles.remove(obs)
+                    if money < 0 and obs["color"] == RED:
+                        crash_obstacle_rect = obs["rect"].copy()
+                        game_state = "crashing"
+                        crash_timer = 0
+                    
+
+        # Update crash state timing
+        if game_state == "crashing":
+            crash_timer += 1
+            if crash_timer > CRASH_ANIMATION_FRAMES:
+                game_state = "game_over"
 
         # Drawing
         screen.fill(BLACK)
-
         # Sidewalks
         pygame.draw.rect(screen, SIDEWALK_COLOR, (0, 0, SIDEWALK_WIDTH, HEIGHT))
         pygame.draw.rect(screen, SIDEWALK_COLOR, (WIDTH - SIDEWALK_WIDTH, 0, SIDEWALK_WIDTH, HEIGHT))
@@ -146,12 +230,19 @@ def main() -> None:
             x = SIDEWALK_WIDTH + i * LANE_WIDTH
             pygame.draw.line(screen, WHITE, (x, 0), (x, HEIGHT), 2)
 
-        # Car
-        pygame.draw.rect(screen, BLUE, car_rect)
+        # Car and crash obstacle
+        if game_state == "crashing" and crash_obstacle_rect:
+            jitter = random.randint(-3, 3)
+            crash_car = car_rect.move(jitter, jitter)
+            crash_obs = crash_obstacle_rect.move(-jitter, jitter)
+            screen.blit(car_surface, crash_car)
+            screen.blit(OBSTACLE_SURFACES[0], crash_obs)
+        else:
+            screen.blit(car_surface, car_rect)
 
         # Obstacles
         for obs in obstacles:
-            pygame.draw.rect(screen, obs["color"], obs["rect"])
+            screen.blit(obs["surface"], obs["rect"])
 
         # Timer
         timer_surface = font.render(f"{elapsed_sec:.1f}", True, WHITE)


### PR DESCRIPTION
## Summary
- draw simple car, money and crate shapes with transparent backgrounds when no custom images are supplied
- update the asset loader to support different placeholder types
- document new placeholders in README

## Testing
- `python -m py_compile car_game.py assets.py`
- `python car_game.py` *(fails: XDG_RUNTIME_DIR invalid)*

------
https://chatgpt.com/codex/tasks/task_b_68555162c6ec8326b03f6bf87affd783